### PR TITLE
Add rollbar support to smith

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+PATH
+  remote: .
+  specs:
+    smith (0.8.7)
+      addressable (~> 2.0)
+      amqp (~> 1.6, ~> 1.0)
+      curses (= 1.0.1)
+      daemons (~> 1.1)
+      eventmachine (~> 1.0)
+      extlib (= 0.9.16)
+      hashie (~> 2.1)
+      logging (~> 2.0)
+      multi_json (~> 1.10)
+      murmurhash3 (= 0.1.4)
+      oj (~> 2.11, >= 2.11.4)
+      protobuf (~> 3.4)
+      rollbar
+      ruby_parser (~> 3.6)
+      state_machine (= 1.1.2)
+      sys-proctable (~> 0.9.0)
+      toml-rb (~> 0.3)
+      trollop (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    amq-protocol (2.2.0)
+    amqp (1.7.0)
+      amq-protocol (>= 2.1.0)
+      eventmachine
+    citrus (3.0.2)
+    concurrent-ruby (1.0.5)
+    curses (1.0.1)
+    daemons (1.2.4)
+    eventmachine (1.2.5)
+    extlib (0.9.16)
+    hashie (2.1.2)
+    i18n (0.8.6)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    middleware (0.1.0)
+    minitest (5.10.3)
+    multi_json (1.12.1)
+    murmurhash3 (0.1.4)
+    oj (2.18.5)
+    protobuf (3.7.5)
+      activesupport (>= 3.2)
+      middleware
+      thor
+      thread_safe
+    public_suffix (3.0.0)
+    rollbar (2.15.1)
+      multi_json
+    ruby_parser (3.10.1)
+      sexp_processor (~> 4.9)
+    sexp_processor (4.10.0)
+    state_machine (1.1.2)
+    sys-proctable (0.9.9-universal-aix5)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    toml-rb (0.3.15)
+      citrus (~> 3.0, > 3.0)
+    trollop (2.1.2)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  smith!
+
+BUNDLED WITH
+   1.15.3

--- a/smith.gemspec
+++ b/smith.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hashie", "~> 2.1"
   s.add_runtime_dependency "toml-rb", "~> 0.3"
   s.add_runtime_dependency "sys-proctable", "~> 0.9.0"
+  s.add_runtime_dependency "rollbar"
 
   if /java/.match(RUBY_PLATFORM)
     s.platform = 'java'


### PR DESCRIPTION
Given we are using Rollbar globally, it's significantly easier to hook into the Smith bootstrap process than to instrument each and every agent.

This PR adds Rollbar instrumentation to Smith, and mandates that a Rollbar token is available in the environment. If not, the agency will fail to start.