### PR TITLE
 Assume the cache path is intended and leave it unchanged

### DIFF
--- a/lib/smith.rb
+++ b/lib/smith.rb
@@ -68,7 +68,7 @@ module Smith
 
     # Return the acl cache path.
     def acl_cache_directory
-      cache_directory.join('acl').tap do |path|
+      cache_directory.tap do |path|
         check_path(path, true)
       end
     end


### PR DESCRIPTION
This change will allow us to directly set the caching path, essential to easily allow the packaging of ACLs inside a gem.