### PR TITLE
Ignore fractions of a second for mtime acl cache comparison

### DIFF
--- a/lib/smith/acl_compiler.rb
+++ b/lib/smith/acl_compiler.rb
@@ -64,7 +64,7 @@ module Smith
     def should_compile?(file)
       cached_file = Smith.acl_cache_directory.join(file.basename).sub_ext(".pb.rb")
       if cached_file.exist?
-        file.mtime > cached_file.mtime
+        file.mtime.to_i > cached_file.mtime.to_i
       else
         true
       end


### PR DESCRIPTION
The caching time comparison in https://github.com/digivizer/smith2/blob/master/lib/smith/acl_compiler.rb#L67 uses `mtime` which is too high a resolution to be practical.

By casting `mtime.to_i` we reduce the resolution and allow a cache hit to take place when the files are, to all extents and purposes, created at the same time.

This assist us in migrating to a gem bundle of ACLs.