### PR TITLE
Bring much of the old autostart branch into master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,83 @@
+PATH
+  remote: .
+  specs:
+    smith (0.8.7)
+      addressable (~> 2.0)
+      amqp (~> 1.6, ~> 1.0)
+      curses (= 1.0.1)
+      daemons (~> 1.1)
+      eventmachine (~> 1.0)
+      extlib (= 0.9.16)
+      hashie (~> 2.1)
+      logging (~> 2.0)
+      multi_json (~> 1.10)
+      murmurhash3 (= 0.1.4)
+      oj (~> 2.11, >= 2.11.4)
+      protobuf (~> 3.4)
+      rollbar
+      ruby_parser (~> 3.6)
+      state_machine (= 1.1.2)
+      sys-proctable (~> 0.9.0)
+      toml-rb (~> 0.3)
+      trollop (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    amq-protocol (2.2.0)
+    amqp (1.7.0)
+      amq-protocol (>= 2.1.0)
+      eventmachine
+    citrus (3.0.2)
+    concurrent-ruby (1.0.5)
+    curses (1.0.1)
+    daemons (1.2.4)
+    eventmachine (1.2.5)
+    extlib (0.9.16)
+    hashie (2.1.2)
+    i18n (0.8.6)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    middleware (0.1.0)
+    minitest (5.10.3)
+    multi_json (1.12.1)
+    murmurhash3 (0.1.4)
+    oj (2.18.5)
+    protobuf (3.7.5)
+      activesupport (>= 3.2)
+      middleware
+      thor
+      thread_safe
+    public_suffix (3.0.0)
+    rollbar (2.15.1)
+      multi_json
+    ruby_parser (3.10.1)
+      sexp_processor (~> 4.9)
+    sexp_processor (4.10.0)
+    state_machine (1.1.2)
+    sys-proctable (0.9.9-universal-aix5)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    toml-rb (0.3.15)
+      citrus (~> 3.0, > 3.0)
+    trollop (2.1.2)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  smith!
+
+BUNDLED WITH
+   1.15.3

--- a/lib/smith/acl_compiler.rb
+++ b/lib/smith/acl_compiler.rb
@@ -92,7 +92,7 @@ module Smith
     end
 
     def load_acl(path)
-      logger.verbose { "Loading ACL: #{path}" }
+      logger.debug { "Loading ACL: #{path}" }
       require path
     end
 

--- a/lib/smith/agent_monitoring.rb
+++ b/lib/smith/agent_monitoring.rb
@@ -12,7 +12,7 @@ module Smith
       EventMachine::add_periodic_timer(1) do
         @agent_processes.each do |agent_process|
           if agent_process.monitor
-            logger.verbose { "Agent state for #{agent_process.name}: #{agent_process.state}" }
+            logger.debug { "Agent state for #{agent_process.name}: #{agent_process.state}" }
             case agent_process.state
             when 'running'
               if agent_process.last_keep_alive

--- a/lib/smith/application/agency.rb
+++ b/lib/smith/application/agency.rb
@@ -108,7 +108,7 @@ module Smith
     def keep_alive(agent_data)
       agent_exists?(agent_data.uuid) do |agent_process|
         agent_process.last_keep_alive = agent_data.time
-        logger.verbose { "Agent keep alive: #{agent_data.uuid}: #{agent_data.time}" }
+        logger.debug { "Agent keep alive: #{agent_data.uuid}: #{agent_data.time}" }
 
         # We need to call save explicitly here as the keep alive is not part of
         # the state_machine which is the thing that writes the state to disc.

--- a/lib/smith/commands/smithctl/dump.rb
+++ b/lib/smith/commands/smithctl/dump.rb
@@ -40,7 +40,7 @@ module Smith
                   Messaging::Queue.number_of_messages(queue) do |queue_length|
                     if queue_length == 0
                       t_end = Time.now.to_f
-                      if options[:verbose]
+                      if options[:debug]
                         responder.succeed("dumped #{count} messages in #{t_end - t_start} seconds.")
                       else
                         responder.succeed("")
@@ -74,7 +74,7 @@ module Smith
         banner "Dump a queue to STDOUT.\n\n  This is a very DANGEROUS command in that it removes all messages from a queue.", "<queue>"
 
         opt    :'yes-i-want-to-remove-all-acls-from-the-queue',  "Remove all acls from the queue and print to stdout", :type => :boolean,  :short => :none
-        opt    :verbose,                                         "Print the number of acls dumped.", :type => :boolean,  :short => :v
+        opt    :debug,                                           "Print the number of acls dumped.", :type => :boolean,  :short => :v
       end
     end
   end

--- a/lib/smith/daemon.rb
+++ b/lib/smith/daemon.rb
@@ -66,7 +66,7 @@ module Smith
     def unlink_pid_file
       p = Pathname.new(@pid.filename)
       if p.exist?
-        logger.verbose { "Removing pid file: #{p.to_s}" }
+        logger.debug { "Removing pid file: #{p.to_s}" }
         p.unlink
       end
     end

--- a/lib/smith/logger.rb
+++ b/lib/smith/logger.rb
@@ -4,10 +4,6 @@ module Smith
 
     def self.included(base)
 
-      if !Logging.initialized?
-        Logging.init([:debug, :info, :warn, :error, :fatal])
-      end
-
       base.class_eval do
         include Methods
         extend Methods

--- a/lib/smith/logger.rb
+++ b/lib/smith/logger.rb
@@ -5,7 +5,7 @@ module Smith
     def self.included(base)
 
       if !Logging.initialized?
-        Logging.init([:verbose, :debug, :info, :warn, :error, :fatal])
+        Logging.init([:debug, :info, :warn, :error, :fatal])
       end
 
       base.class_eval do

--- a/lib/smith/messaging/receiver.rb
+++ b/lib/smith/messaging/receiver.rb
@@ -100,7 +100,7 @@ module Smith
                 if payload
                   on_message(metadata, payload, requeue_options, &blk)
                 else
-                  logger.verbose { "Received null message on: #{@queue_def.denormalise} [options]:#{opts}" }
+                  logger.debug { "Received null message on: #{@queue_def.denormalise} [options]:#{opts}" }
                 end
               end
             else

--- a/lib/smith/messaging/requeue.rb
+++ b/lib/smith/messaging/requeue.rb
@@ -35,8 +35,8 @@ module Smith
             o[:type] = @metadata.type
           end
 
-          logger.verbose { "Requeuing to: #{@queue.name} [options]: #{opts}" }
-          logger.verbose { "Requeuing to: #{@queue.name} [message]: #{@message.to_hash}" }
+          logger.debug { "Requeuing to: #{@queue.name} [options]: #{opts}" }
+          logger.debug { "Requeuing to: #{@queue.name} [message]: #{@message.to_hash}" }
 
           @exchange.publish(@message, opts)
         end

--- a/lib/smith/messaging/responder.rb
+++ b/lib/smith/messaging/responder.rb
@@ -6,7 +6,7 @@ module Smith
       include EventMachine::Deferrable
 
       def value(value=nil, &blk)
-        logger.verbose { "Running responders: #{(value || blk).inspect}" }
+        logger.debug { "Running responders: #{(value || blk).inspect}" }
         value ||= ((blk) ? blk.call : nil)
         set_deferred_status(:succeeded, value)
       end

--- a/lib/smith/messaging/sender.rb
+++ b/lib/smith/messaging/sender.rb
@@ -69,7 +69,7 @@ module Smith
         if @reply_queue_completion
           @reply_queue_completion.completion do |reply_queue|
             message_id = random
-            logger.verbose { "message_id: #{message_id}" }
+            logger.debug { "message_id: #{message_id}" }
 
             #### !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ####
             #### TODO if there is a timeout delete   ####
@@ -188,8 +188,8 @@ module Smith
       private
 
       def _publish(message, opts, &blk)
-        logger.verbose { "Publishing to: [queue]: #{@queue_def.denormalise}. [options]: #{opts}" }
-        logger.verbose { "ACL content: [queue]: #{@queue_def.denormalise}, [metadata type]: #{message.class}, [message]: #{message.inspect}" }
+        logger.debug { "Publishing to: [queue]: #{@queue_def.denormalise}. [options]: #{opts}" }
+        logger.debug { "ACL content: [queue]: #{@queue_def.denormalise}, [metadata type]: #{message.class}, [message]: #{message.inspect}" }
 
         increment_counter
 

--- a/lib/smith/messaging/util.rb
+++ b/lib/smith/messaging/util.rb
@@ -23,19 +23,19 @@ module Smith
 
       def open_channel(opts={}, &blk)
         AMQP::Channel.new(Smith.connection) do |channel,ok|
-          logger.verbose { "Opened channel: #{"%x" % channel.object_id}" }
+          logger.debug { "Opened channel: #{"%x" % channel.object_id}" }
 
           # Set up auto-recovery. This will ensure that amqp will
           # automatically reconnet to the broker if there is an error.
           channel.auto_recovery = true
-          logger.verbose { "Channel auto recovery set to ture" }
+          logger.debug { "Channel auto recovery set to ture" }
 
           # Set up QOS. If you do not do this then any subscribes will get
           # overwhelmed if there are too many messages.
           prefetch = opts[:prefetch] || Smith.config.agent.prefetch
 
           channel.prefetch(prefetch)
-          logger.verbose { "AMQP prefetch set to: #{prefetch}" }
+          logger.debug { "AMQP prefetch set to: #{prefetch}" }
 
           blk.call(channel)
         end

--- a/smith.gemspec
+++ b/smith.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hashie", "~> 2.1"
   s.add_runtime_dependency "toml-rb", "~> 0.3"
   s.add_runtime_dependency "sys-proctable", "~> 0.9.0"
+  s.add_runtime_dependency "rollbar"
 
   if /java/.match(RUBY_PLATFORM)
     s.platform = 'java'

--- a/smith.gemspec
+++ b/smith.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   if /java/.match(RUBY_PLATFORM)
     s.platform = 'java'
   else
-    s.add_runtime_dependency 'oj', '~> 2.11', '>= 2.11.4'
+    s.add_runtime_dependency 'oj'#, '~> 2.11', '>= 2.11.4'
     s.add_runtime_dependency("curses", "1.0.1")
   end
 

--- a/spec/lib/logger_spec.rb
+++ b/spec/lib/logger_spec.rb
@@ -65,9 +65,6 @@ describe Smith::Logger do
     end
 
     it 'should work for all log levels when logger is invoked as a class method' do
-      Smith::ClassUnderTest.send(:log_level, :verbose)
-      log_output = Smith::ClassUnderTest.capture_stdout { Smith::ClassUnderTest.send(:logger).verbose("class log message") }
-      log_output.should == "VERBOSE - Smith::ClassUnderTest: - class log message\n"
       Smith::ClassUnderTest.send(:log_level, :debug)
       log_output = Smith::ClassUnderTest.capture_stdout { Smith::ClassUnderTest.send(:logger).debug("class log message") }
       log_output.should == "  DEBUG - Smith::ClassUnderTest: - class log message\n"
@@ -86,9 +83,6 @@ describe Smith::Logger do
     end
 
     it 'should work for all log levels when logger is invoked as an instance method' do
-      cut.send(:log_level, :verbose)
-      log_output = Smith::ClassUnderTest.capture_stdout { cut.send(:logger).verbose("instance log message") }
-      log_output.should == "VERBOSE - Smith::ClassUnderTest: - instance log message\n"
       cut.send(:log_level, :debug)
       log_output = Smith::ClassUnderTest.capture_stdout { cut.send(:logger).debug("instance log message") }
       log_output.should == "  DEBUG - Smith::ClassUnderTest: - instance log message\n"


### PR DESCRIPTION
* Remove `verbose` logging and replace with `debug`
* Initialize Rollbar to ensure startup and subsequent exceptions are captured
* Loosen the dependency requirements for OJ