### PR TITLE
[WIP] Introduce grpc-tools and protobuf 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+PATH
+  remote: .
+  specs:
+    smith (0.8.8)
+      addressable (~> 2.0)
+      amqp (~> 1.6, ~> 1.0)
+      curses (= 1.0.1)
+      daemons (~> 1.1)
+      eventmachine (~> 1.0)
+      extlib (= 0.9.16)
+      google-protobuf
+      grpc-tools (~> 1.11.0)
+      hashie (~> 2.1)
+      logging (~> 2.0)
+      multi_json (~> 1.10)
+      murmurhash3 (= 0.1.4)
+      oj (~> 2.11, >= 2.11.4)
+      protobuf (~> 3.4)
+      ruby_parser (~> 3.6)
+      state_machine (= 1.1.2)
+      sys-proctable (~> 0.9.0)
+      toml-rb (~> 0.3)
+      trollop (~> 2.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    amq-protocol (2.3.0)
+    amqp (1.8.0)
+      amq-protocol (>= 2.2.0)
+      eventmachine
+    citrus (3.0.2)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5)
+    curses (1.0.1)
+    daemons (1.2.6)
+    eventmachine (1.2.5)
+    extlib (0.9.16)
+    google-protobuf (3.5.1.2)
+    grpc-tools (1.11.0)
+    hashie (2.1.2)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    method_source (0.9.0)
+    middleware (0.1.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    murmurhash3 (0.1.4)
+    oj (2.18.5)
+    protobuf (3.8.2)
+      activesupport (>= 3.2)
+      middleware
+      thor
+      thread_safe
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    public_suffix (3.0.2)
+    ruby_parser (3.11.0)
+      sexp_processor (~> 4.9)
+    sexp_processor (4.11.0)
+    state_machine (1.1.2)
+    sys-proctable (0.9.9-universal-aix5)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    toml-rb (0.3.15)
+      citrus (~> 3.0, > 3.0)
+    trollop (2.1.2)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  smith!
+
+BUNDLED WITH
+   1.16.1

--- a/lib/smith/acl_compiler.rb
+++ b/lib/smith/acl_compiler.rb
@@ -41,7 +41,7 @@ module Smith
 
       unless acls.empty?
         Dir.chdir(path) do
-          cmd = %Q{sh -c 'protoc --ruby_out=#{Smith.acl_cache_directory} -I #{path} #{out_of_date_acls.map(&:to_s).join(' ')} 2>&1'}
+          cmd = %Q{sh -c 'grpc_tools_ruby_protoc --ruby_out=#{Smith.acl_cache_directory} -I #{path} #{out_of_date_acls.map(&:to_s).join(' ')} 2>&1'}
           protoc = IO.popen(cmd)
           output = protoc.read
           protoc.close
@@ -60,9 +60,9 @@ module Smith
       {:file => e[0], :line => e[1], :pos => e[2], :error => e[3,-1]}
     end
 
-    # Returns true if the .proto file is newer that the .pb.rb file
+    # Returns true if the .proto file is newer that the _pb.rb file
     def should_compile?(file)
-      cached_file = Smith.acl_cache_directory.join(file.basename).sub_ext(".pb.rb")
+      cached_file = Smith.acl_cache_directory.join(file.basename).sub_ext("_pb.rb")
       if cached_file.exist?
         file.mtime > cached_file.mtime
       else
@@ -109,7 +109,7 @@ module Smith
     end
 
     def acl_compiled_path(path)
-      "#{Smith.acl_cache_directory.join(path.basename('.proto'))}.pb.rb"
+      "#{Smith.acl_cache_directory.join(path.basename('.proto'))}_pb.rb"
     end
   end
 end

--- a/lib/smith/messaging/acl/agency_command.proto
+++ b/lib/smith/messaging/acl/agency_command.proto
@@ -1,9 +1,11 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgencyCommand {
-  required string command = 1;
+  string command = 1;
   repeated string args = 2;
 }
 
 message AgencyCommandResponse {
-  optional string response = 1;
+  string response = 1;
 }

--- a/lib/smith/messaging/acl/agent_command.proto
+++ b/lib/smith/messaging/acl/agent_command.proto
@@ -1,5 +1,7 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgentCommand {
-  required string command = 1;
+  string command = 1;
   repeated string options = 2;
 }

--- a/lib/smith/messaging/acl/agent_config_request.proto
+++ b/lib/smith/messaging/acl/agent_config_request.proto
@@ -1,4 +1,6 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgentConfigRequest {
-  required string agent = 1;
+  string agent = 1;
 }

--- a/lib/smith/messaging/acl/agent_config_update.proto
+++ b/lib/smith/messaging/acl/agent_config_update.proto
@@ -1,5 +1,7 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgentConfigUpdate {
-  required string agent = 1;
-  required string value = 2;
+  string agent = 1;
+  string value = 2;
 }

--- a/lib/smith/messaging/acl/agent_keepalive.proto
+++ b/lib/smith/messaging/acl/agent_keepalive.proto
@@ -1,6 +1,8 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgentKeepalive {
-  optional string  uuid = 1;
-  required string name = 2;
-  optional int64 time = 3;
+  string  uuid = 1;
+  string name = 2;
+  int64 time = 3;
 }

--- a/lib/smith/messaging/acl/agent_lifecycle.proto
+++ b/lib/smith/messaging/acl/agent_lifecycle.proto
@@ -1,18 +1,20 @@
+syntax = "proto3";
+
 package Smith.ACL;
 
 message AgentAcknowledgeStart {
-  required string   uuid = 1;
-  required int32    pid = 2;
-  required int64    started_at = 3;
-  optional bool     singleton = 4;
-  optional bool     monitor = 5;
-  optional string   metadata = 6;
+  string   uuid = 1;
+  int32    pid = 2;
+  int64    started_at = 3;
+  bool     singleton = 4;
+  bool     monitor = 5;
+  string   metadata = 6;
 }
 
 message AgentAcknowledgeStop {
-  required string   uuid = 1;
+  string   uuid = 1;
 }
 
 message AgentDead {
-  required string   uuid = 1;
+  string   uuid = 1;
 }

--- a/lib/smith/messaging/acl/agent_stats.proto
+++ b/lib/smith/messaging/acl/agent_stats.proto
@@ -1,15 +1,17 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message AgentStats {
   message QueueStats {
-    required string   name = 1;
-    required string   type = 2;
-    required int32    length = 3;
+    string   name = 1;
+    string   type = 2;
+    int32    length = 3;
   }
 
-  required string       uuid = 1;
-  required string       agent_name = 2;
-  required int32        pid = 3;
-  optional int64        rss = 4;
-  required int64        up_time = 5;
+  string       uuid = 1;
+  string       agent_name = 2;
+  int32        pid = 3;
+  int64        rss = 4;
+  int64        up_time = 5;
   repeated QueueStats   queues = 6;
 }

--- a/lib/smith/messaging/acl/search.proto
+++ b/lib/smith/messaging/acl/search.proto
@@ -1,8 +1,10 @@
+syntax = "proto3";
+
 package Smith.ACL;
 message SearchResponse {
   message Result {
-    required string url = 1;
-    optional string title = 2;
+    string url = 1;
+    string title = 2;
     repeated string snippets = 3;
   }
   repeated Result result = 1;

--- a/smith.gemspec
+++ b/smith.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "hashie", "~> 2.1"
   s.add_runtime_dependency "toml-rb", "~> 0.3"
   s.add_runtime_dependency "sys-proctable", "~> 0.9.0"
+  s.add_runtime_dependency "grpc-tools", "~> 1.11.0"
+  s.add_runtime_dependency "google-protobuf"
+  s.add_development_dependency "pry"
 
   if /java/.match(RUBY_PLATFORM)
     s.platform = 'java'


### PR DESCRIPTION
Our preference is to avoid platform dependencies as much as possible,
but using protocol buffers will always require the protoc compiler.

Google publish a static binary as part of `grpc-tools`, and this changeset
adopts that gem and compiler. As a result of this, we must also change
the base protobuf to version 3. For Digivizer, this means that we must
remove 'optional' and 'required' params from the schema.

Another change is that ruby-compiled protobufs are now suffixed with
`_pb.rb`, from `.pb.rb`. This change affects Smith compilation and
loading, so the compiler has been adapted to account for this.

This changeset is very much WIP, so patience is appreciated!